### PR TITLE
SchedulerARMAVR: Add used attribute to coopSchedule

### DIFF
--- a/SchedulerARMAVR/SchedulerARMAVR.cpp
+++ b/SchedulerARMAVR/SchedulerARMAVR.cpp
@@ -46,7 +46,7 @@ typedef struct CoopTask {
 
 static CoopTask *cur = 0;
 
-static CoopTask* __attribute__((noinline)) coopSchedule(char taskDied) {
+static CoopTask* __attribute__((noinline)) __attribute__((used)) coopSchedule(char taskDied) {
 	CoopTask* next = cur->next;
 
 	if (taskDied) {


### PR DESCRIPTION
Arduino AVR Boards 1.6.12 and newer have added LTO. This seems to cause
coopSchedule to be optimized away, resulting in the example sketch not
compiling. By adding the used attribute this is prevented.

It's unclear from the repository's branch structure which branch I should submit this pull request to. If master is not the correct branch please let me know and I'll resubmit the pull request to the correct branch.