### PR TITLE
prevents compiler to fail in Arduino 1.6.10+ and platformIO

### DIFF
--- a/SCoop/SCoop.cpp
+++ b/SCoop/SCoop.cpp
@@ -182,6 +182,7 @@ static inline micros_t SCoopMicros16(void) // same as standrad PJRC micros, but 
 		  
 #else // end of CORE_TEENSY. Now same job for the Arduino wiring.c library
 extern volatile unsigned long timer0_overflow_count; // use this variable which is incremented at each overflow
+static unsigned long tell_compiler_that_i_really_need_this = timer0_overflow_count;	// ugly hack to force the compiler to REALLY keep timer0_overflow_count
 static inline micros_t SCoopMicros16(void) __attribute__((always_inline));
 static inline micros_t SCoopMicros16(void) // same as standrad PJRC micros, but in 16 bits and with inlining
 {	register micros_t out ;


### PR DESCRIPTION
Hi Fabrice.
Thank you for this great Library that I often use to implement pseudo multi tasking in my Arduino projects.

As stated in issue #4 , the latest Arduino IDEs (as well as PlatformIO) are unable to compil the Scoop Library due to the fact that they ignore the *timer0_overflow_count* declaration, because it is only used in the next *asm volatile* declaration... 

While my c++ skills are really limited, this very simple hack, force the compiler  to use the timer0_overflow_count variable, and thus fixes the compilation issue.

I hope you will merge it and/or replace it with a more elegant fix.

Best regards,